### PR TITLE
Add no_std support 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/unicode-rs/unicode-properties"
 documentation = "https://docs.rs/unicode-properties"
 license = "MIT/Apache-2.0"
 keywords = ["text", "unicode"]
+categories = ["no-std::no-alloc"]
 readme = "README.md"
 description = """
 Query character Unicode properties according to

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,7 @@
 //!
 //! Provides the emoji character properties of a character.
 //!
+#![no_std]
 #![deny(missing_docs)]
 
 #[rustfmt::skip]


### PR DESCRIPTION
The library didn't use any std so just add `#![no_std]` attribute to force no_std.

~~Also fixed the test cases.~~

This is needed to preserve no_std capability of rustybuzz which is currently using unicode-properties, https://github.com/RazrFalcon/rustybuzz/pull/71.