### PR TITLE
Allow converting the GeneralCategory to a GeneralCategoryGroup

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,6 +158,20 @@ pub mod general_category {
             crate::tables::general_category::general_category_of_char(self)
         }
     }
+
+    impl UnicodeGeneralCategory for GeneralCategory {
+        #[inline(always)]
+        fn general_category(self) -> GeneralCategory {
+            self
+        }
+    }
+
+    impl From<GeneralCategory> for GeneralCategoryGroup {
+        #[inline(always)]
+        fn from(value: GeneralCategory) -> Self {
+            value.general_category_group()
+        }
+    }
 }
 
 pub use tables::UNICODE_VERSION;

--- a/tests/general_category.rs
+++ b/tests/general_category.rs
@@ -1,5 +1,7 @@
 #![cfg(feature = "general-category")]
 
+use unicode_properties::UnicodeGeneralCategory;
+
 #[test]
 fn general_category_test() {
     use std::ops::Not;
@@ -20,4 +22,129 @@ fn general_category_test() {
     assert_eq!('🦀'.general_category(), GeneralCategory::OtherSymbol);
     assert_eq!('🦀'.general_category_group(), GeneralCategoryGroup::Symbol);
     assert!('🦀'.is_letter_cased().not());
+}
+
+#[test]
+fn all_general_categories_to_group() {
+    use unicode_properties::{GeneralCategory, GeneralCategoryGroup};
+    assert_eq!(
+        GeneralCategory::UppercaseLetter.general_category_group(),
+        GeneralCategoryGroup::Letter
+    );
+    assert_eq!(
+        GeneralCategory::LowercaseLetter.general_category_group(),
+        GeneralCategoryGroup::Letter
+    );
+    assert_eq!(
+        GeneralCategory::TitlecaseLetter.general_category_group(),
+        GeneralCategoryGroup::Letter
+    );
+    assert_eq!(
+        GeneralCategory::ModifierLetter.general_category_group(),
+        GeneralCategoryGroup::Letter
+    );
+    assert_eq!(
+        GeneralCategory::OtherLetter.general_category_group(),
+        GeneralCategoryGroup::Letter
+    );
+    assert_eq!(
+        GeneralCategory::NonspacingMark.general_category_group(),
+        GeneralCategoryGroup::Mark
+    );
+    assert_eq!(
+        GeneralCategory::SpacingMark.general_category_group(),
+        GeneralCategoryGroup::Mark
+    );
+    assert_eq!(
+        GeneralCategory::EnclosingMark.general_category_group(),
+        GeneralCategoryGroup::Mark
+    );
+    assert_eq!(
+        GeneralCategory::DecimalNumber.general_category_group(),
+        GeneralCategoryGroup::Number
+    );
+    assert_eq!(
+        GeneralCategory::LetterNumber.general_category_group(),
+        GeneralCategoryGroup::Number
+    );
+    assert_eq!(
+        GeneralCategory::OtherNumber.general_category_group(),
+        GeneralCategoryGroup::Number
+    );
+    assert_eq!(
+        GeneralCategory::ConnectorPunctuation.general_category_group(),
+        GeneralCategoryGroup::Punctuation
+    );
+    assert_eq!(
+        GeneralCategory::DashPunctuation.general_category_group(),
+        GeneralCategoryGroup::Punctuation
+    );
+    assert_eq!(
+        GeneralCategory::OpenPunctuation.general_category_group(),
+        GeneralCategoryGroup::Punctuation
+    );
+    assert_eq!(
+        GeneralCategory::ClosePunctuation.general_category_group(),
+        GeneralCategoryGroup::Punctuation
+    );
+    assert_eq!(
+        GeneralCategory::InitialPunctuation.general_category_group(),
+        GeneralCategoryGroup::Punctuation
+    );
+    assert_eq!(
+        GeneralCategory::FinalPunctuation.general_category_group(),
+        GeneralCategoryGroup::Punctuation
+    );
+    assert_eq!(
+        GeneralCategory::OtherPunctuation.general_category_group(),
+        GeneralCategoryGroup::Punctuation
+    );
+    assert_eq!(
+        GeneralCategory::MathSymbol.general_category_group(),
+        GeneralCategoryGroup::Symbol
+    );
+    assert_eq!(
+        GeneralCategory::CurrencySymbol.general_category_group(),
+        GeneralCategoryGroup::Symbol
+    );
+    assert_eq!(
+        GeneralCategory::ModifierSymbol.general_category_group(),
+        GeneralCategoryGroup::Symbol
+    );
+    assert_eq!(
+        GeneralCategory::OtherSymbol.general_category_group(),
+        GeneralCategoryGroup::Symbol
+    );
+    assert_eq!(
+        GeneralCategory::SpaceSeparator.general_category_group(),
+        GeneralCategoryGroup::Separator
+    );
+    assert_eq!(
+        GeneralCategory::LineSeparator.general_category_group(),
+        GeneralCategoryGroup::Separator
+    );
+    assert_eq!(
+        GeneralCategory::ParagraphSeparator.general_category_group(),
+        GeneralCategoryGroup::Separator
+    );
+    assert_eq!(
+        GeneralCategory::Control.general_category_group(),
+        GeneralCategoryGroup::Other
+    );
+    assert_eq!(
+        GeneralCategory::Format.general_category_group(),
+        GeneralCategoryGroup::Other
+    );
+    assert_eq!(
+        GeneralCategory::Surrogate.general_category_group(),
+        GeneralCategoryGroup::Other
+    );
+    assert_eq!(
+        GeneralCategory::PrivateUse.general_category_group(),
+        GeneralCategoryGroup::Other
+    );
+    assert_eq!(
+        GeneralCategory::Unassigned.general_category_group(),
+        GeneralCategoryGroup::Other
+    );
 }


### PR DESCRIPTION
This was sparked by me having to implement my own `GeneralCategory` to `GeneralCategoryGroup` for a parser.

* Implemented the `UnicodeGeneralCategory` trait for `GeneralCategory` itself to allow the same queries as against a `char`
* Implement `From<GeneralCategory>` for `UnicodeGeneralCategoryGroup`
* Implement tests to make sure the `.general_category_group()` lookup works as expected